### PR TITLE
Refine estimate for FX rate

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -3,7 +3,7 @@
     "current_season": "2022",
     "start_date": "2022-05-01",
     "estimates": [{
-        "fx_min": 0.62,
+        "fx_min": 0.63,
         "fx_max": 0.64,
         "cost_min": 2.0,
         "cost_max": 2.4,


### PR DESCRIPTION
I was looking at the numbers, and it's pretty hard for Fonterra to get below 0.63, given that I estimate they had already hedged 2/3 of their cashflows at a rate of 0.66.